### PR TITLE
Theme improvement

### DIFF
--- a/frontend/components/Block.tsx
+++ b/frontend/components/Block.tsx
@@ -6,23 +6,27 @@ export const BlockContainer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
-  padding: 3px;
-  background-color: #434343;
+  padding: 12px 3px;
+  background-color: rgba(255,255,255,0.1);
   box-shadow: #000 3px 3px 14px;
   border-radius: 6px;
   margin-bottom: 30px;
 `;
 
 export const BlockStyle = styled.div<{ signals?: boolean }>`
-  background: ${(props) =>
-    props.signals
-      ? "linear-gradient(45deg, rgba(18,209,0,1) 0%, rgba(9,89,0,1) 100%)"
-      : "linear-gradient(45deg, rgba(209,0,0,1) 0%, rgba(89,0,0,1) 100%)"};
-  border: 1px solid #434343;
+  background: ${(props) => props.signals ? "#1DB492" : "#737474"};
+  border: 1px solid rgba(255,255,255,0.1);
   width: 18px;
   height: 18px;
   margin: 3px;
   border-radius: 4px;
+  &:after {
+    content: ${(props) => props.signals ? "'•'" : "' '"};
+    color: rgba(255,255,255,0.5);
+    right: 4px;
+    bottom: -1px;
+    position: absolute;
+  }
 `;
 
 export const EmptyBlock = styled.div`
@@ -31,6 +35,7 @@ export const EmptyBlock = styled.div`
   height: 18px;
   margin: 3px;
   border-radius: 4px;
+  position: relative;
 `;
 
 export interface IBlockProps {

--- a/frontend/components/ProgressBar.tsx
+++ b/frontend/components/ProgressBar.tsx
@@ -41,8 +41,8 @@ const Green = styled.div<{ roundedRightBorder?: boolean }>`
   font-size: 13px;
   justify-content: center;
   align-items: center;
-  background: linear-gradient(45deg, #217f35 0%, rgba(9, 89, 0, 1) 100%);
-  border: 1px solid #1ed947;
+  background: #1DB492;
+  border: 1px solid #1DB492;
   border-top-left-radius: 6px;
   border-bottom-left-radius: 6px;
   border-top-right-radius: ${(props) => (props.roundedRightBorder ? "6px" : "0px")};
@@ -55,8 +55,8 @@ const White = styled.div<{ roundedLeftBorder?: boolean; roundedRightBorder?: boo
   font-size: 13px;
   justify-content: center;
   align-items: center;
-  background: linear-gradient(45deg, #8e8e8e 0%, #afafaf 100%);
-  border: 1px solid #f7f7f7;
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.1);
   border-top-left-radius: ${(props) => (props.roundedLeftBorder ? "6px" : "0px")};
   border-bottom-left-radius: ${(props) => (props.roundedLeftBorder ? "6px" : "0px")};
   border-top-right-radius: ${(props) => (props.roundedRightBorder ? "6px" : "0px")};
@@ -69,8 +69,8 @@ const Red = styled.div<{ roundedLeftBorder?: boolean }>`
   font-size: 13px;
   justify-content: center;
   align-items: center;
-  background: linear-gradient(45deg, #731212 0%, rgba(89, 0, 0, 1) 100%);
-  border: 1px solid #c30000;
+  background: #737474;
+  border: 1px solid #737474;
   box-sizing: border-box;
   border-radius: 0px 6px 6px 0px;
   border-top-right-radius: 6px;

--- a/frontend/components/SiteTitle.tsx
+++ b/frontend/components/SiteTitle.tsx
@@ -7,8 +7,7 @@ const Title = styled.h1`
   margin: 40px 0 20px;
   font-size: 42px;
   text-align: center;
-  color: #d97b08;
-  text-shadow: #000 3px 3px 0px;
+  color: #fff;
   position: relative;
 `;
 

--- a/frontend/pages/about.tsx
+++ b/frontend/pages/about.tsx
@@ -14,8 +14,7 @@ import ContactTwitter from "../components/ContactTwitter.tsx";
 const Header = styled.p`
   font-size: 24px;
   margin-bottom: 10px;
-  color: #ff9b20;
-  text-shadow: #000 2px 2px 0px;
+  color: #1DB492;
 `;
 
 const InfoContainer = styled.div`

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -22,24 +22,24 @@ const DescriptionBlock = styled.div`
 `;
 
 const TopSection = styled.div`
-  display: flex;
-  justify-content: space-between;
   align-items: center;
 `;
 
 const CurrentPeriod = styled.h2`
   font-size: 24px;
   margin-bottom: 10px;
-  color: #ff9b20;
-  text-shadow: #000 2px 2px 0px;
+  color: #fff;
 `;
 
 const LockinInfo = styled.h2`
-  font-size: 16px;
-  text-align: right;
-  margin-bottom: 10px;
-  color: #ff9b20;
-  text-shadow: #000 2px 2px 0px;
+  font-size: 14px;
+  margin-bottom: 24px;
+  color: #fff;
+  background: rgba(255,255,255,0.1);
+  border-radius: 20px;
+  font-weight: 500;
+  padding: 8px 16px;
+  display: inline-block;
 `;
 
 const BootstrappingInProgress = styled.p`
@@ -73,7 +73,7 @@ export default function Blocks() {
         </DescriptionBlock>
         {blocks.length > 0 && <ProgressBar />}
         <TopSection>
-          <CurrentPeriod>Current signalling period of 2016 blocks</CurrentPeriod>
+          <CurrentPeriod>2016 blocks period</CurrentPeriod>
           {/* <LockinInfo>90% of blocks within the period have to signal.</LockinInfo> */}
           <LockinInfo>
             {lockedIn && <>{forkName.toUpperCase()} IS LOCKED IN FOR DEPLOYMENT!</>}
@@ -81,8 +81,8 @@ export default function Blocks() {
               <>
                 {!currentPeriodFailed && (
                   <>
-                    {blocksLeftForActivation} {forkName} blocks left until softfork is locked in.
-                    <br />
+                    {blocksLeftForActivation} {forkName} blocks left until softfork is locked in
+                    
                     {willProbablyActivate && (
                       <>Taproot will lock in with the current signalling ratio ({currentSignallingPercentage}%)!</>
                     )}
@@ -93,9 +93,7 @@ export default function Blocks() {
                 )}
                 {currentPeriodFailed && (
                   <>
-                    {forkName} cannot be locked in within this period.
-                    <br />
-                    (90% of the blocks have to signal).
+                    {forkName} cannot be locked in within this period (90% of the blocks have to signal).
                   </>
                 )}
               </>

--- a/frontend/pages/miners.tsx
+++ b/frontend/pages/miners.tsx
@@ -14,7 +14,7 @@ import ContactTwitter from "../components/ContactTwitter.tsx";
 
 const Table = styled.table`
   width: 100%;
-  max-width: 1000px;
+  max-width: 1024px;
   box-shadow: #000 3px 3px 14px;
   border-radius: 6px;
   margin: 0 auto 30px;
@@ -65,8 +65,7 @@ const SignallingCell = styled.td`
 
 const Totals = styled.div`
   font-size: 24px;
-  color: #ff9b20;
-  text-shadow: #000 2px 2px 0px;
+  color: #1DB492;
   max-width: 600px;
   margin: auto;
   text-align: center;

--- a/frontend/style/site.css
+++ b/frontend/style/site.css
@@ -7,7 +7,11 @@ body,
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji",
     "Segoe UI Emoji", "Segoe UI Symbol";
-  background-color: #242424;
+  background-color: #111111;
+}
+a {
+  text-decoration: none;
+  position: relative;
 }
 
 /* GitHib corner button */


### PR DESCRIPTION
Fix for color blindness by adding different shapes for all blocks.

<img width="131" alt="Screenshot 2021-05-04 at 18 32 27" src="https://user-images.githubusercontent.com/1238429/117037724-15f9c980-ad07-11eb-9555-719bd51ad1dc.png">

General review of the theme colors. Highlights with the main color (green) what is needed and removes the red.

<img width="1427" alt="Screenshot 2021-05-04 at 18 20 10" src="https://user-images.githubusercontent.com/1238429/117037615-fb275500-ad06-11eb-921a-bc36c11e5d52.png">

