### PR TITLE
Add accumulated miner share column

### DIFF
--- a/frontend/pages/miners.tsx
+++ b/frontend/pages/miners.tsx
@@ -96,6 +96,7 @@ export default function Miners() {
   const totalSignallingPotentialRatio = miners
     .filter(([_, m]) => m.numSignallingBlocks > 0)
     .reduce((sum, [_, m]) => sum + m.numBlocks / currentNumberOfBlocks, 0);
+  let accumulatedShare = 0;
 
   return (
     <Container>
@@ -118,6 +119,7 @@ export default function Miners() {
             <TableRow>
               <TableHeader>Miner name</TableHeader>
               <TableHeader>Share</TableHeader>
+              <TableHeader>Accumulated share</TableHeader>
               <TableHeader>Blocks</TableHeader>
               <TableHeader>Signals</TableHeader>
             </TableRow>
@@ -125,6 +127,8 @@ export default function Miners() {
 
           <TableBody>
             {miners.map(([key, miner]) => {
+              const share = miner.numBlocks / currentNumberOfBlocks;
+              accumulatedShare += share;
               return (
                 <TableRow key={key}>
                   <Cell>
@@ -135,7 +139,8 @@ export default function Miners() {
                     )}
                     {!miner.website && miner.name}
                   </Cell>
-                  <Cell>{((miner.numBlocks / currentNumberOfBlocks) * 100).toFixed(2)}%</Cell>
+                  <Cell>{(share * 100).toFixed(2)}%</Cell>
+                  <Cell>{(accumulatedShare * 100).toFixed(2)}%</Cell>
                   <SignallingCell>
                     <Anchor href={`/miner/${miner.name}`}>
                       {miner.numSignallingBlocks}/{miner.numBlocks + " "}

--- a/frontend/pages/miners.tsx
+++ b/frontend/pages/miners.tsx
@@ -119,7 +119,7 @@ export default function Miners() {
             <TableRow>
               <TableHeader>Miner name</TableHeader>
               <TableHeader>Share</TableHeader>
-              <TableHeader>Accumulated share</TableHeader>
+              <TableHeader className="collapse-by-640">Accumulated share</TableHeader>
               <TableHeader>Blocks</TableHeader>
               <TableHeader>Signals</TableHeader>
             </TableRow>
@@ -140,7 +140,7 @@ export default function Miners() {
                     {!miner.website && miner.name}
                   </Cell>
                   <Cell>{(share * 100).toFixed(2)}%</Cell>
-                  <Cell>{(accumulatedShare * 100).toFixed(2)}%</Cell>
+                  <Cell className="collapse-by-640">{(accumulatedShare * 100).toFixed(2)}%</Cell>
                   <SignallingCell>
                     <Anchor href={`/miner/${miner.name}`}>
                       {miner.numSignallingBlocks}/{miner.numBlocks + " "}

--- a/frontend/style/site.css
+++ b/frontend/style/site.css
@@ -10,6 +10,13 @@ body {
   background-color: #242424;
 }
 
+/* For hiding colums on small screens */
+@media only screen and (max-width: 640px) {
+  .collapse-by-640 {
+      display: none;
+  }
+}
+
 /* GitHib corner button */
 .github-corner:hover .octo-arm {
   animation: octocat-wave 560ms ease-in-out;


### PR DESCRIPTION
A column for accumulated mining share is added on screens with a width over 640px.

This closes #63. 