### PR TITLE
next period start estimation wording improvement

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -86,7 +86,7 @@ export default function Blocks() {
             <CannotLockInInfo>
               The current period cannot lock in {forkName}.
               <br />
-              The next period starts in approximately
+              The next period starts in
               {" " + formatDistanceToNow(addMinutes(new Date(), blocksLeftInThisPeriod * 10), {}) + " "}(
               {blocksLeftInThisPeriod} block{blocksLeftInThisPeriod > 1 && "s"})
             </CannotLockInInfo>


### PR DESCRIPTION
Currently what the page shows is this: `The next period starts in approximately about 18 hours (106 blocks)

"Approximately about" is of course incorrect, and it stems from the fact that date-range formatting library inserts the `about`. I think it's simpler just to avoid the approximately. 

Alternatively it could say "The next period is estimated to start in..." and then the "about" won't be a problem. My personal preference is for the above shorter phrasing.