### PR TITLE
Update miner identifiers with latest

### DIFF
--- a/common/miners.ts
+++ b/common/miners.ts
@@ -156,6 +156,10 @@ const miners: IMiners = {
       name: "GHash.IO",
       link: "https://ghash.io/",
     },
+    "MARA Pool": {
+      name: "MARA Pool",
+      link: "https://marathondh.com/",
+    },
     "st mining corp": {
       name: "ST Mining Corp",
       link: "https://bitcointalk.org/index.php?topic=77000.msg3207708#msg3207708",


### PR DESCRIPTION
Update with latest from https://raw.githubusercontent.com/0xB10C/known-mining-pools/master/pools.json. There is only one new entry for MARA pool.